### PR TITLE
chore: Add Notion API database object type

### DIFF
--- a/types/types.ts
+++ b/types/types.ts
@@ -28,3 +28,38 @@ export type ArticleMetaProps = CardProps;
 export type Params = ParsedUrlQuery & {
   slug: string;
 };
+
+export type FileType = {
+  file?: { url: string };
+  external?: { url: string };
+};
+
+export type AnnotationType = {
+  bold: boolean;
+  code: boolean;
+  italic: boolean;
+  strikethrough: boolean;
+  underline: boolean;
+  color: string;
+};
+
+export type RichTextType = {
+  plain_text: string;
+  href: string | null;
+  annotations: AnnotationType;
+};
+
+export type PropertyType = {
+  name: { title: RichTextType[] };
+  author: { rich_text: RichTextType[] };
+  slug: { rich_text: RichTextType[] };
+  published: { date: { start: string } };
+  isPublic: { checkbox: boolean };
+  tags: { multi_select: [{ name: string }] };
+};
+
+export type PageType = {
+  id: string;
+  cover: FileType | null;
+  properties: PropertyType;
+};


### PR DESCRIPTION
44. 45. PageType https://www.udemy.com/course/notion-next-blog/learn/lecture/33004136#notes


Notion API Database object

https://developers.notion.com/reference/database