### PR TITLE
Add filter for fetching Notion pages

### DIFF
--- a/pages/articles/[slug].tsx
+++ b/pages/articles/[slug].tsx
@@ -1,13 +1,14 @@
 import Image from "next/image";
 import React from "react";
-import { GetServerSideProps, NextPage } from "next";
+import { GetStaticProps, NextPage } from "next";
 
 import Layout from "../../components/Layout";
 import ArticleMeta from "../../components/ArticleMeta";
 import { ArticleProps, Params } from "../../types/types";
 import { sampleCards } from "../../utils/sample";
 
-export const getServerSideProps: GetServerSideProps = async (ctx) => {
+// export const getServerSideProps: GetServerSideProps = async (ctx) => {
+export const getStaticProps: GetStaticProps = async (ctx) => {
   const { slug } = ctx.params as Params; // [slug].tsx
 
   const page = sampleCards.find((data) => data.slug === slug);

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -7,7 +7,7 @@ import { fetchPages } from "../utils/notion";
 import { IndexProps } from "../types/types";
 
 export const getStaticProps: GetStaticProps = async () => {
-  const { results } = await fetchPages();
+  const { results } = await fetchPages({});
 
   return {
     props: {

--- a/utils/notion.ts
+++ b/utils/notion.ts
@@ -5,8 +5,42 @@ const notion = new Client({ auth: process.env.NOTION_KEY });
 
 const DATABASE_ID = process.env.NOTION_DATABASE_ID as string;
 
-export const fetchPages = async () => {
+export const fetchPages = async ({ slug }: { slug?: string }) => {
+  // ? any 使う以外に、もうちょい上手いやり方ないかな？
+  const and: any = [
+    {
+      property: "isPublic",
+      checkbox: {
+        equals: true,
+      },
+    },
+    {
+      property: "slug",
+      rich_text: {
+        is_not_empty: true,
+      },
+    },
+  ];
+
+  if (slug) {
+    and.push({
+      property: "slug",
+      rich_text: {
+        equals: slug,
+      },
+    });
+  }
+
   return await notion.databases.query({
     database_id: DATABASE_ID,
+    filter: {
+      and: and,
+    },
+    sorts: [
+      {
+        property: "published",
+        direction: "descending",
+      },
+    ],
   });
 };


### PR DESCRIPTION
60. fetchPagesへフィルター追加 https://www.udemy.com/course/notion-next-blog/learn/lecture/33007526#notes

詳細ページのエラー画面が https://github.com/ayumubanban/ex-tak-notion-cms-next-blog/pull/21#issue-1337924510 から変わった。このエラーは、全記事で表示される

> Server Error
> Error: getStaticPaths is required for dynamic SSG pages and is missing for '/articles/[slug]'.
> Read more: https://nextjs.org/docs/messages/invalid-getstaticpaths-value

https://user-images.githubusercontent.com/35994367/184498122-a23d5147-b349-457c-b546-2624ca302023.mov



