### PR TITLE
Modify components/ArticleMeta.tsx

### DIFF
--- a/components/ArticleMeta.tsx
+++ b/components/ArticleMeta.tsx
@@ -2,6 +2,7 @@ import Image from "next/image";
 import React, { FC } from "react";
 
 import { ArticleMetaProps } from "../types/types";
+import { getCover, getDate, getMultiSelect, getText } from "../utils/property";
 
 const ArticleMeta: FC<ArticleMetaProps> = ({ page }) => {
   return (
@@ -9,7 +10,7 @@ const ArticleMeta: FC<ArticleMetaProps> = ({ page }) => {
       {/* page cover */}
       <Image
         className="w-full max-w-screen-lg rounded-lg aspect-video my-4"
-        src={page.cover}
+        src={getCover(page.cover)}
         alt=""
         objectFit="cover"
         width={640}
@@ -18,24 +19,30 @@ const ArticleMeta: FC<ArticleMetaProps> = ({ page }) => {
       />
 
       {/* page name */}
-      <h1 className="my-8">{page.name}</h1>
+      <h1 className="my-8">{getText(page.properties.name.title)}</h1>
       <div className="bg-gray-100 px-6 py-4 rounded text-sm text-gray-500">
         <div className="grid grid-cols-3 gap-4">
           {/* published */}
           <div className="col-span-1">Published</div>
-          <div className="col-span-2">{page.published}</div>
+          <div className="col-span-2">
+            {getDate(page.properties.published.date)}
+          </div>
 
           {/* author */}
           <div className="col-span-1">Author</div>
-          <div className="col-span-2">{page.author}</div>
+          <div className="col-span-2">
+            {getText(page.properties.author.rich_text)}
+          </div>
 
           {/* tags */}
           <div className="col-span-1">Tags</div>
           <div className="col-span-2">
             {/* change later */}
-            {page.tags.map((tag: string, index: number) => (
-              <span key={index}>{`#${tag} `}</span>
-            ))}
+            {getMultiSelect(page.properties.tag.multi_select).map(
+              (tag: string, index: number) => (
+                <span key={index}>{`#${tag} `}</span>
+              )
+            )}
           </div>
         </div>
       </div>

--- a/pages/articles/[slug].tsx
+++ b/pages/articles/[slug].tsx
@@ -47,7 +47,6 @@ export const getStaticProps: GetStaticProps = async (ctx) => {
 const Article: NextPage<ArticleProps> = ({ page, blocks }) => {
   console.log(page);
   console.log(blocks);
-  return <></>;
 
   return (
     <Layout>


### PR DESCRIPTION
68. ArticleMetaの修正 https://www.udemy.com/course/notion-next-blog/learn/lecture/33008770#notes

これで、エラー出ずに記事詳細ページが表示されるようにはなった。

https://user-images.githubusercontent.com/35994367/184499656-b2a05f81-f15b-4ebe-bc9c-d90bc49ee2d8.mov


